### PR TITLE
Make wait() non blocking.

### DIFF
--- a/election.go
+++ b/election.go
@@ -279,6 +279,16 @@ func (e *Election) isInit() bool {
 		return e.inited
 	}
 
+	// drain the stop channel
+loop:
+	for {
+		select {
+		case <-e.stop:
+		default:
+			break loop
+		}
+	}
+
 	e.inited = false
 	e.disableLeader()
 	e.destroyCurrentSession()


### PR DESCRIPTION
This should ensures that a call to Election.Stop() returns much more
quickly,
before it could take up to .CheckoutTime until the .Stop() call returns.

A blocking Stop() can mean, that a service is not stopped in time, e.g. systemd may kill it, and e.g. consul session will not be cleaned up before the TTL expires.